### PR TITLE
Solves issue #18 [Normalize attention weights with `dim_split` instead of `self.dim_V`]

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -25,7 +25,7 @@ class MAB(nn.Module):
         K_ = torch.cat(K.split(dim_split, 2), 0)
         V_ = torch.cat(V.split(dim_split, 2), 0)
 
-        A = torch.softmax(Q_.bmm(K_.transpose(1,2))/math.sqrt(self.dim_V), 2)
+        A = torch.softmax(Q_.bmm(K_.transpose(1,2))/math.sqrt(dim_split), 2)
         O = torch.cat((Q_ + A.bmm(V_)).split(Q.size(0), 0), 2)
         O = O if getattr(self, 'ln0', None) is None else self.ln0(O)
         O = O + F.relu(self.fc_o(O))


### PR DESCRIPTION
When attention weights are normalized using `self.dim_V`, values of `A` are relatively smaller which might affect the convergence. I think it's essential to normalize attention weights with `dim_split`.